### PR TITLE
Updating the storage account name

### DIFF
--- a/WebLogicOnAKS/SetupSimpleClusterManually/README.md
+++ b/WebLogicOnAKS/SetupSimpleClusterManually/README.md
@@ -129,7 +129,7 @@ Create storage account first:
 
 ```
 # Change the value as needed for your own environment
-AKS_PERS_STORAGE_ACCOUNT_NAME=wlssimpleclusterstorageaccount
+AKS_PERS_STORAGE_ACCOUNT_NAME=wlssimplestorageacct
 
 az storage account create \
    -n $AKS_PERS_STORAGE_ACCOUNT_NAME \


### PR DESCRIPTION
Just for the reader,  the storage account name validation: The field can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.